### PR TITLE
Update to Python3

### DIFF
--- a/src/rosserial_stm32/make_libraries.py
+++ b/src/rosserial_stm32/make_libraries.py
@@ -71,14 +71,14 @@ ROS_TO_EMBEDDED_TYPES = {
 
 # need correct inputs
 if (len(sys.argv) < 2):
-    print __usage__
+    print(__usage__)
     exit()
     
 # get output path
 path = sys.argv[1]
 if path[-1] == "/":
     path = path[0:-1]
-print "\nExporting to %s" % path
+print(("\nExporting to %s" % path))
 
 rospack = rospkg.RosPack()
 


### PR DESCRIPTION
Accroding to [ROS Target Platforms](https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025), the targeted Python is version 3.8. Also, [Ubuntu Release Note on 20.04](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Python3_by_default), the python included in the base system is Python 3.8.