### PR TITLE
HAL_UART_Transmit_DMA param bugfix

### DIFF
--- a/src/ros_lib/STM32Hardware.h
+++ b/src/ros_lib/STM32Hardware.h
@@ -104,7 +104,7 @@ class STM32Hardware {
 		  }else{
 			len = tbuflen - tfind;
 			HAL_UART_Transmit_DMA(huart, &(tbuf[tfind]), len);
-			HAL_UART_Transmit_DMA(huart, &(tbuf), twind);
+			HAL_UART_Transmit_DMA(huart, &(tbuf[0]), twind);
 		  }
           tfind = twind;
         }


### PR DESCRIPTION
the second param of HAL_UART_Transmit_DMA should be a pointer to uint8_t, not a pointer to pointer.